### PR TITLE
print coverage report

### DIFF
--- a/bin/coverage
+++ b/bin/coverage
@@ -1,0 +1,10 @@
+#! /usr/bin/env node
+
+'use strict'
+
+const gulp = require('gulp')
+
+require('../src/gulp-log')(gulp)
+require('../gulp')(gulp)
+
+gulp.start('coverage')

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dignified-lint": "bin/lint",
     "dignified-build": "bin/build",
     "dignified-test": "bin/test",
-    "dignified-release": "bin/release"
+    "dignified-release": "bin/release",
+    "dignified-coverage": "bin/coverage"
   },
   "scripts": {
     "lint": "bin/lint"
@@ -40,6 +41,7 @@
     "gulp-eslint": "^2.0.0",
     "gulp-filter": "^4.0.0",
     "gulp-git": "^1.7.1",
+    "gulp-istanbul": "^0.10.4",
     "gulp-load-plugins": "^1.2.0",
     "gulp-load-tasks": "^0.8.4",
     "gulp-mocha": "^2.2.0",

--- a/tasks/coverage.js
+++ b/tasks/coverage.js
@@ -1,0 +1,30 @@
+'use strict'
+
+const $ = require('gulp-load-plugins')()
+
+const utils = require('../src/utils')
+const config = require('../config/webpack')
+
+module.exports = {
+  fn (gulp, done) {
+    gulp.task('pre-test', function () {
+      return gulp.src([
+        'src/**/*.js'
+      ]).pipe($.istanbul())
+        .pipe($.istanbul.hookRequire())
+    })
+
+    gulp.task('mocha', ['pre-test'], () => {
+      return gulp.src([
+        'test/node.js',
+        'test/**/*.spec.js'
+      ])
+        .pipe($.mocha({
+          timeout: config.dev.timeout
+        }))
+        .pipe($.istanbul.writeReports())
+    })
+
+    utils.hooksRun(gulp, 'coverage', ['mocha'], utils.exitOnFail(done))
+  }
+}


### PR DESCRIPTION
This prints the coverage reports after the tests are run. Though adding it as a separate step, but that would mean tests are run twice, which can be very expensive for some of our modules that have very long tests.

Also, by printing the reports but not strictly enforcing a coverage minimum, we make devs aware of how the changes impacted the overall coverage.

What do you think?